### PR TITLE
DW_AT_data_member_location only stores the offset without the name now

### DIFF
--- a/struct_layout.py
+++ b/struct_layout.py
@@ -219,7 +219,7 @@ class DwarfMember:
 	def __init__(self, item, types):
 		self._types = types
 		self._underlying_type = item['fields']['DW_AT_type'].split()[0]
-		self._offset = int(item['fields']['DW_AT_data_member_location'].split()[1], 0)
+		self._offset = int(item['fields']['DW_AT_data_member_location'], 0)
 		if 'DW_AT_name' in item['fields']:
 			self._name = item['fields']['DW_AT_name']
 		else:


### PR DESCRIPTION
This change occurs when moving from the OSX 10.9 SDK -> 10.15 SDK..

ex:

```python
{'fields': {'DW_AT_name': 'member_name', 'DW_AT_type': '0x000002fa "class_name"', 'DW_AT_decl_file': 'src/test.h', 'DW_AT_decl_line': '364', 'DW_AT_data_member_location': '0x00'}, 'tag': 'DW_TAG_member', 'addr': '0x000000b2', 'has_children': False}
```